### PR TITLE
fix(security): update nodemailer to 9.1.1 in notification service

### DIFF
--- a/server/services/notification/package-lock.json
+++ b/server/services/notification/package-lock.json
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
-      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.1.tgz",
+      "integrity": "sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/server/services/notification/package.json
+++ b/server/services/notification/package.json
@@ -8,6 +8,6 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "kafkajs": "^2.2.4",
-    "nodemailer": "^9.0.1"
+    "nodemailer": "^9.1.1"
   }
 }


### PR DESCRIPTION
## Description
Updates nodemailer in server/services/notification to 9.1.1 to resolve Dependabot security alerts:#122, #123, #124, and #125.

### Vulnerabilities Fixed:
- GHSA-2x7j-588g-ccc2 (High - DoS via addressparser)
- GHSA-wmmp-3585-3rmp (Moderate - IDN/Punycode allow-list bypass)
- GHSA-cc9r-2j5m-2m83 (Moderate - Recipient domain validation bypass)
- GHSA-8m3c-c648-2xjj (Moderate - resolveContent file/URL access bypass)

## Verification
- Ran npm audit in server/services/notification: 0 vulnerabilities found.